### PR TITLE
Handle URI containing search parameters

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -20,6 +20,8 @@
         <source-file src="src/ios/CDVCrypt.m" />
         <header-file src="src/ios/CDVCryptURLProtocol.h" />
         <source-file src="src/ios/CDVCryptURLProtocol.m" />
+
+        <hook type="after_prepare" src="hooks/after_prepare.js" />
     </platform>
 
     <platform name="android">
@@ -31,8 +33,8 @@
         </config-file>
 
         <source-file src="src/android/com/tkyaji/cordova/DecryptResource.java" target-dir="src/com/tkyaji/cordova" />
-    </platform>
 
-    <hook type="after_prepare" src="hooks/after_prepare.js" />
+        <hook type="after_prepare" src="hooks/after_prepare.js" />
+    </platform>
 
 </plugin>

--- a/src/android/com/tkyaji/cordova/DecryptResource.java
+++ b/src/android/com/tkyaji/cordova/DecryptResource.java
@@ -48,7 +48,7 @@ public class DecryptResource extends CordovaPlugin {
 
     @Override
     public CordovaResourceApi.OpenForReadResult handleOpenForRead(Uri uri) throws IOException {
-        String uriStr = this.tofileUri(this.launchUri);
+        String uriStr = this.tofileUri(this.launchUri.split("\\?")[0]);
         CordovaResourceApi.OpenForReadResult readResult =  this.webView.getResourceApi().openForRead(Uri.parse(uriStr), true);
 
         if (!isCryptFiles(uriStr)) {


### PR DESCRIPTION
Some URIs contain search parameters (e.g. - http://localhost/mypage.html?parm1=123).  In this case, we need to ignore everything past the file name in order to read the source.