### PR TITLE
Handle URI containing search parameters

### DIFF
--- a/src/android/com/tkyaji/cordova/DecryptResource.java
+++ b/src/android/com/tkyaji/cordova/DecryptResource.java
@@ -47,7 +47,7 @@ public class DecryptResource extends CordovaPlugin {
     @Override
     public CordovaResourceApi.OpenForReadResult handleOpenForRead(Uri uri) throws IOException {
         Uri oriUri = this.fromPluginUri(uri);
-        String uriStr = oriUri.toString().replace("/+++/", "/");
+        String uriStr = oriUri.toString().replace("/+++/", "/").split("\\?")[0];
 
         CordovaResourceApi.OpenForReadResult readResult =  this.webView.getResourceApi().openForRead(Uri.parse(uriStr), true);
 


### PR DESCRIPTION
1.2 release broke this feature.  This change restores it.