### PR TITLE
Include and exclude directories

### DIFF
--- a/hooks/after_prepare.js
+++ b/hooks/after_prepare.js
@@ -31,7 +31,7 @@ module.exports = function(context) {
         var wwwDir = platformInfo.locations.www;
 
         findCryptFiles(wwwDir).filter(function(file) {
-            return isCryptFile(file.replace(wwwDir, ''));
+            return isCryptFile(file.replace(wwwDir + '/', '').replace(wwwDir + '\\', '').replace(wwwDir, ''));
         }).forEach(function(file) {
             var content = fs.readFileSync(file, 'utf-8');
             fs.writeFileSync(file, encryptData(content, key, iv), 'utf-8');
@@ -109,6 +109,10 @@ module.exports = function(context) {
     }
 
     function isCryptFile(file) {
+        if(fs.statSync(file).isDirectory()) {
+            return false;
+        }
+        file = file.replace(new RegExp('\\\\'), '/');
         if (!targetFiles.include.some(function(regexStr) { return new RegExp(regexStr).test(file); })) {
             return false;
         }


### PR DESCRIPTION
Normalize after_prepare,js and Decryptor class to work the same, allowing to include and exclude directories:
<file regex="^lib/" />

Delete full paths including slash:
/home/proyect/www/lib/my_lib.js -> lib/my_lib.js (Encrypt)
file:///android_asset/www/lib/my_lib.js -> lib/my_lib.js (Decrypt)

Fix Windows path separators (Encrypt)
C:\Users\user1\proyect\www\lib\my_lib.js -> lib/my_lib.js (Encrypt)